### PR TITLE
Implement Job Creation API Endpoint - A POST example

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -16,22 +16,19 @@ export default function Home() {
   });
 
   const { data: jobs, isLoading } = useQuery<JobWithCompany[]>({
-    queryKey: [
-      "/api/jobs",
-      search,
-      filters.location,
-      filters.type,
-      filters.company,
-    ],
-    queryFn: ({ queryKey: [url, q, location, type, company] }) =>
-      fetch(
-        `${url}?${new URLSearchParams({
-          ...(q ? { q: q as string } : {}),
-          ...(location ? { location: location as string } : {}),
-          ...(type ? { type: type as string } : {}),
-          ...(company ? { company: company as string } : {}),
-        })}`
-      ).then((r) => r.json()),
+    queryKey: ["/api/jobs", search, filters],
+    queryFn: async () => {
+      // Build query params
+      const params = new URLSearchParams();
+      if (search) params.set('q', search);
+      if (filters.location) params.set('location', filters.location);
+      if (filters.type) params.set('type', filters.type);
+      if (filters.company) params.set('company', filters.company);
+
+      // Simple fetch
+      const response = await fetch(`/api/jobs?${params}`);
+      return response.json();
+    }
   });
 
   const handleSearch = (e: React.FormEvent) => {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,13 +1,31 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { SearchIcon } from "lucide-react";
 import SearchFilters from "@/components/search-filters";
 import JobCard from "@/components/job-card";
-import type { JobWithCompany } from "@shared/schema";
+import type { JobWithCompany, InsertJob } from "@shared/schema";
 
 export default function Home() {
+  const queryClient = useQueryClient();
+
+  // Example mutation for creating a job
+  const { mutate: createJob, isPending: isCreating } = useMutation({
+    mutationFn: async (newJob: InsertJob) => {
+      const response = await fetch('/api/jobs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newJob)
+      });
+      if (!response.ok) throw new Error('Failed to create job');
+      return response.json();
+    },
+    // After successful creation, refresh the jobs list
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/jobs'] });
+    }
+  });
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState({
     location: "",

--- a/client/src/pages/job.tsx
+++ b/client/src/pages/job.tsx
@@ -9,7 +9,11 @@ export default function Job() {
   const { id } = useParams();
   
   const { data: job, isLoading } = useQuery<JobWithCompany>({
-    queryKey: [`/api/jobs/${id}`],
+    queryKey: ["/api/jobs", id],
+    queryFn: async () => {
+      const response = await fetch(`/api/jobs/${id}`);
+      return response.json();
+    }
   });
 
   if (isLoading) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -30,6 +30,17 @@ export async function registerRoutes(app: Express) {
     res.json(job);
   });
 
+  app.post("/api/jobs", async (req, res) => {
+    try {
+      const newJob = req.body;
+      const job = await storage.createJob(newJob);
+      res.status(201).json(job);
+    } catch (error) {
+      console.error("Error creating job:", error);
+      res.status(500).json({ message: "Failed to create job" });
+    }
+  });
+
   const httpServer = createServer(app);
   return httpServer;
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6,6 +6,7 @@ export interface IStorage {
   getJobs(): Promise<JobWithCompany[]>;
   getJob(id: number): Promise<JobWithCompany | undefined>;
   searchJobs(query: string, filters: { location?: string; type?: string; company?: string }): Promise<JobWithCompany[]>;
+  createJob(job: InsertJob): Promise<JobWithCompany>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -67,6 +68,22 @@ export class DatabaseStorage implements IStorage {
     }
 
     return result;
+  }
+
+  async createJob(job: InsertJob): Promise<JobWithCompany> {
+    // Insert the job
+    const [newJob] = await db
+      .insert(jobs)
+      .values(job)
+      .returning();
+
+    // Get the full job with company details
+    const jobWithCompany = await this.getJob(newJob.id);
+    if (!jobWithCompany) {
+      throw new Error('Failed to create job');
+    }
+
+    return jobWithCompany;
   }
 }
 


### PR DESCRIPTION
We want to ensure this exercise tests a candidate’s full-stack fundamental knowledge and coding ability.

As it stands, the current question is too difficult to complete end-to-end within the allotted time, especially for Software Engineer 4 candidates, who are typically new graduates.

To improve fairness and signal quality, I'm suggesting this pr to:
- Simplifying the query patterns to reduce unnecessary complexity.
- Providing a POST request example so candidates spend less time looking up syntax and more time demonstrating their problem-solving and coding skills.